### PR TITLE
[fix](doc): PR#15– remove links from titles

### DIFF
--- a/ChatGPT/ChatGPTHaikus.md
+++ b/ChatGPT/ChatGPTHaikus.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: ChatGPT/[ChatGPT](https://chat.openai.com/) Haikus
+title: ChatGPT/ChatGPT Haikus
 permalink: /ChatGPT/
 ---
 

--- a/ChatGPT/ChatGPTHaikusBucketLists.md
+++ b/ChatGPT/ChatGPTHaikusBucketLists.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: ChatGPT/[ChatGPT](https://chat.openai.com/) Haikus — Lists of Bucket Lists  
+title: ChatGPT/ChatGPT Haikus — Lists of Bucket Lists  
 permalink: /ChatGPT/
 ---
 

--- a/ChatGPT/ChattingWithChatGPT.md
+++ b/ChatGPT/ChattingWithChatGPT.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: ChatGPT/Chatting with [ChatGPT](https://chat.openai.com/)
+title: ChatGPT/Chatting with ChatGPT
 permalink: /ChatGPT/
 ---
 

--- a/Computing/GitHubCompanyGovernment.md
+++ b/Computing/GitHubCompanyGovernment.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Computing/GitHub — Company / Government [GitHub Repositories](https://github.com/) and [GitHub](https://github.com/ )
+title: Computing/GitHub — Company / Government GitHub Repositories and GitHub References 
 permalink: /Computing/
 ---
 

--- a/FoodDrink/HootersRestaurantsVisited.md
+++ b/FoodDrink/HootersRestaurantsVisited.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: FoodDrink/[Hooter Restaurants Visited](https://www.hooters.com)
+title: FoodDrink/Hooter Restaurants Visited
 permalink: /FoodDrink/
 ---
 

--- a/FoodDrink/TabascoScovilleRating.md
+++ b/FoodDrink/TabascoScovilleRating.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: FoodDrink/Tabasco Sauce Scoville Rating [^1]
+title: FoodDrink/Tabasco Sauce Scoville Rating
 permalink: /FoodDrink/
 ---
 

--- a/Government/NASA.md
+++ b/Government/NASA.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Government/[NASA](https://www.nasa.gov/)
+title: Government/NASA
 permalink: /Government/
 ---
 

--- a/Hardware/SparkFun.md
+++ b/Hardware/SparkFun.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Hardware/[SparkFun](https://sparkfun.com/)
+title: Hardware/SparkFun
 permalink: /Hardware/
 ---
 

--- a/Media/LexingtonMedicalChannels.md
+++ b/Media/LexingtonMedicalChannels.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Media/[Lexington Medical Center Channel Lineup/Schedule](https://www.lexmed.com/)[^11][^12][^13]
+title: Media/Lexington Medical Center Channel Lineup/Schedule
 permalink: /Media/
 ---
 

--- a/Media/YouTubeSubscribedChannels.md
+++ b/Media/YouTubeSubscribedChannels.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Media/[YouTube](https://youtube.com/) Subscribed Channels
+title: Media/YouTube Subscribed Channels
 permalink: /Media/
 ---
 

--- a/ScienceFiction/StarTrekFranchise.md
+++ b/ScienceFiction/StarTrekFranchise.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Science Fiction/[Star Trek Franchise](https://www.startrek.com/)  
+title: Science Fiction/Star Trek Franchise  
 permalink: /ScienceFiction/
 ---
 

--- a/Shopping/PublixGasCard.md
+++ b/Shopping/PublixGasCard.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: Shopping/[Publix](https://www/publix.com/) Gas Card Coupon Sales Dates[^11]
+title: Shopping/Publix Gas Card Coupon Sales Dates[^11]
 permalink: /Shopping/
 ---
 

--- a/USC/USCGamecockSandstorm.md
+++ b/USC/USCGamecockSandstorm.md
@@ -1,6 +1,6 @@
 ---
 layout: page
-title: [USC/University of South Carolina](https://www.sc.edu)
+title: USC/University of South Carolina
 permalink: /USC/
 ---
 


### PR DESCRIPTION
Removing the link from USC fixed the Jekyll front matter problem 